### PR TITLE
bumped up mqtt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/relayr/node-relayr",
   "dependencies": {
     "bunyan": "^1.3.4",
-    "mqtt": "1.0.10",
+    "mqtt": "^1.4.0",
     "request": "^2.45.0"
   }
 }


### PR DESCRIPTION
Bumped up the mqtt dependency to make it work with node-v4.5.0, v6.3.1 and v6.4.0

issue:
https://github.com/relayr/node-relayr/issues/11